### PR TITLE
Add RX5808 5.8GHz analog FM detection firmware and mesh-mapper support

### DIFF
--- a/mesh-mapper.py
+++ b/mesh-mapper.py
@@ -806,8 +806,10 @@ def update_detection(detection):
             detection["basic_id"] = tracked_pairs[mac]["basic_id"]
         
         # Comprehensive FAA data persistence logic for no-GPS detections
+        # Skip FAA lookup for RX5808 analog FM detections — they carry no valid
+        # RemoteID that could match the FAA registration database.
         remote_id = detection.get("basic_id")
-        if mac:
+        if mac and not detection.get("_skip_faa"):
             # Exact match if basic_id provided
             if remote_id:
                 key = (mac, remote_id)
@@ -904,7 +906,7 @@ def update_detection(detection):
         detection["basic_id"] = tracked_pairs[mac]["basic_id"]
     remote_id = detection.get("basic_id")
     # Try exact cache lookup by (mac, remote_id), then fallback to any cached data for this mac, then to previous tracked_pairs entry
-    if mac:
+    if mac and not detection.get("_skip_faa"):
         # Exact match if basic_id provided
         if remote_id:
             key = (mac, remote_id)
@@ -4079,19 +4081,35 @@ def serial_reader(port):
                     if 'heartbeat' in detection:
                         logger.debug(f"Skipping heartbeat from {port}")
                         continue
-                    
+
+                    # Skip status/info messages without detection data
+                    if 'info' in detection and not any(k in detection for k in ['mac', 'drone_lat', 'pilot_lat', 'basic_id', 'remote_id']):
+                        logger.debug(f"Skipping info message from {port}: {detection}")
+                        continue
+
                     # Skip status messages without detection data
                     if not any(key in detection for key in ['mac', 'drone_lat', 'pilot_lat', 'basic_id', 'remote_id']):
                         logger.debug(f"Skipping non-detection message from {port}: {detection}")
                         continue
-                        
+
+                    # RX5808 analog FM detection — log prominently, skip FAA lookup
+                    if detection.get('type') == 'analog_fm':
+                        logger.info(
+                            f"[RX5808] Analog FM signal: "
+                            f"Band={detection.get('band','?')}{detection.get('ch','?')} "
+                            f"Freq={detection.get('freq_mhz','?')}MHz "
+                            f"RSSI_raw={detection.get('rssi_raw','?')} "
+                            f"node={detection.get('node_id','?')} port={port}"
+                        )
+                        detection['_skip_faa'] = True
+
                     # Normalize remote_id field
                     if 'remote_id' in detection and 'basic_id' not in detection:
                         detection['basic_id'] = detection['remote_id']
-                    
+
                     # Add port information for debugging
                     detection['source_port'] = port
-                    
+
                     # Process the detection
                     logger.info(f"Processing detection from {port}: MAC={detection.get('mac', 'N/A')}, "
                               f"RSSI={detection.get('rssi', 'N/A')}, "

--- a/rx5808-detection/platformio.ini
+++ b/rx5808-detection/platformio.ini
@@ -1,0 +1,8 @@
+[env:seeed_xiao_esp32s3]
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/stable/platform-espressif32.zip
+framework = arduino
+board = seeed_xiao_esp32s3
+monitor_speed = 115200
+build_flags = -std=gnu++17
+lib_deps =
+  bblanchon/ArduinoJson@^6.18.5

--- a/rx5808-detection/src/main.cpp
+++ b/rx5808-detection/src/main.cpp
@@ -1,0 +1,183 @@
+/*
+ * RX5808 5.8GHz Analog FM Detection — XIAO ESP32-S3
+ *
+ * Scans all 40 standard FPV channels (Raceband + Bands A/B/E/F) and emits a
+ * JSON detection on USB Serial whenever RSSI exceeds the configured threshold,
+ * indicating a nearby 5.8GHz analog FM video transmitter (FPV drone).
+ *
+ * Output
+ *   USB Serial  — JSON lines consumed by mesh-mapper.py
+ *   Serial1 UART (TX=GPIO5, RX=GPIO6) — compact text for Heltec/Meshtastic relay
+ *                                        (set ENABLE_MESH_RELAY 0 to disable)
+ *
+ * Wiring (XIAO ESP32-S3)
+ *   GPIO9  (D10) → RX5808 DATA
+ *   GPIO7  (D8)  → RX5808 CLK
+ *   GPIO8  (D9)  → RX5808 CS
+ *   GPIO1  (D0)  ← RX5808 RSSI  (analog, 0–3.3V)
+ *   3.3V         → RX5808 VCC
+ *   GND          → RX5808 GND
+ *
+ *   GPIO5  (D4)  → Heltec RX  (optional mesh relay)
+ *   GPIO6  (D5)  ← Heltec TX  (optional mesh relay)
+ *
+ * Detection JSON example
+ *   {"type":"analog_fm","mac":"AF:00:16:1A:52:01","freq_mhz":5658,
+ *    "band":"R","ch":1,"rssi_raw":2240,"rssi":2240,
+ *    "basic_id":"5.8G-R1-5658MHz","node_id":"RX01"}
+ */
+
+#include <Arduino.h>
+#include <HardwareSerial.h>
+#include <ArduinoJson.h>
+#include "rx5808.h"
+
+// ============================================================
+// Configuration
+// ============================================================
+
+// Set to 0 if you are not wiring a Heltec LoRa V3 for mesh relay
+#define ENABLE_MESH_RELAY  1
+
+// UART pins for Heltec relay (same as all other firmware variants)
+static const int SERIAL1_TX_PIN = 5;
+static const int SERIAL1_RX_PIN = 6;
+
+// Per-device identifier used for multi-node deduplication in mesh-mapper.py
+#define NODE_ID  "RX01"
+
+// Number of consecutive RSSI reads that must exceed the threshold before
+// a detection is reported. Raising this reduces burst false positives.
+#define MIN_DWELL_HITS  2
+
+// Minimum milliseconds between repeat reports for the same channel.
+// Prevents flooding the serial port when a strong signal is parked on one freq.
+#define REPORT_INTERVAL_MS  5000UL
+
+// ============================================================
+// State
+// ============================================================
+
+static unsigned long last_heartbeat_ms = 0;
+static unsigned long last_report_ms[40] = {};  // one entry per channel index
+
+// ============================================================
+// Helpers
+// ============================================================
+
+// Build a stable synthetic MAC from frequency + band + channel so that
+// mesh-mapper.py can track each FPV channel as a distinct "device".
+//   byte 0: 0xAF  (locally-administered, Analog FM marker)
+//   byte 1: 0x00
+//   bytes 2-3: frequency in MHz, big-endian
+//   byte 4: ASCII band letter
+//   byte 5: channel number
+static void channel_to_mac(const FPVChannel& chan, char* out_mac) {
+    snprintf(out_mac, 18, "AF:00:%02X:%02X:%02X:%02X",
+             (chan.freq_mhz >> 8) & 0xFF,
+              chan.freq_mhz       & 0xFF,
+             (uint8_t)chan.band[0],
+              chan.ch);
+}
+
+static void emit_detection(int idx, int rssi_raw) {
+    const FPVChannel& chan = FPV_CHANNELS[idx];
+
+    char mac[18];
+    channel_to_mac(chan, mac);
+
+    // basic_id carries human-readable channel info visible in mesh-mapper.py
+    char basic_id[24];
+    snprintf(basic_id, sizeof(basic_id), "5.8G-%s%d-%uMHz",
+             chan.band, chan.ch, chan.freq_mhz);
+
+    StaticJsonDocument<256> doc;
+    doc["type"]      = "analog_fm";
+    doc["mac"]       = mac;
+    doc["freq_mhz"]  = chan.freq_mhz;
+    doc["band"]      = chan.band;
+    doc["ch"]        = chan.ch;
+    doc["rssi_raw"]  = rssi_raw;
+    doc["rssi"]      = rssi_raw;   // mesh-mapper.py reads this field for RSSI display
+    doc["basic_id"]  = basic_id;
+    doc["node_id"]   = NODE_ID;
+
+    serializeJson(doc, Serial);
+    Serial.println();
+
+#if ENABLE_MESH_RELAY
+    // Keep the relay message under Meshtastic's 230-byte payload limit
+    char relay[128];
+    snprintf(relay, sizeof(relay),
+             "AnalogFM: %s%d %uMHz rssi=%d [%s]",
+             chan.band, chan.ch, chan.freq_mhz, rssi_raw, NODE_ID);
+    if (Serial1.availableForWrite() >= (int)strlen(relay) + 2)
+        Serial1.println(relay);
+#endif
+}
+
+static void emit_heartbeat() {
+    StaticJsonDocument<128> doc;
+    doc["heartbeat"]  = true;
+    doc["node_id"]    = NODE_ID;
+    doc["scanning"]   = true;
+    doc["channels"]   = FPV_CHANNEL_COUNT;
+    doc["threshold"]  = RSSI_THRESHOLD;
+    serializeJson(doc, Serial);
+    Serial.println();
+}
+
+// ============================================================
+// Arduino entry points
+// ============================================================
+
+void setup() {
+    Serial.begin(115200);
+    // Give the host a moment to open the port before emitting anything
+    while (!Serial && millis() < 3000) {}
+
+#if ENABLE_MESH_RELAY
+    Serial1.begin(115200, SERIAL_8N1, SERIAL1_RX_PIN, SERIAL1_TX_PIN);
+#endif
+
+    rx5808_init();
+
+    Serial.printf(
+        "{\"info\":\"RX5808 scanner ready\",\"node_id\":\"%s\","
+        "\"channels\":%d,\"threshold\":%d}\n",
+        NODE_ID, FPV_CHANNEL_COUNT, RSSI_THRESHOLD
+    );
+}
+
+void loop() {
+    unsigned long now = millis();
+
+    // Periodic heartbeat (skipped by mesh-mapper.py's heartbeat filter)
+    if (now - last_heartbeat_ms >= 60000UL) {
+        emit_heartbeat();
+        last_heartbeat_ms = now;
+    }
+
+    // Sequential channel scan
+    for (int i = 0; i < FPV_CHANNEL_COUNT; i++) {
+        rx5808_set_frequency(FPV_CHANNELS[i].freq_mhz);
+        delay(TUNE_SETTLE_MS);
+
+        // Require MIN_DWELL_HITS consecutive reads above threshold
+        int hits = 0;
+        int rssi  = 0;
+        for (int j = 0; j < MIN_DWELL_HITS; j++) {
+            rssi = rx5808_read_rssi();
+            if (rssi >= RSSI_THRESHOLD) hits++;
+            delay(5);
+        }
+
+        if (hits >= MIN_DWELL_HITS) {
+            // Rate-limit repeated reports for the same channel
+            if (now - last_report_ms[i] >= REPORT_INTERVAL_MS) {
+                emit_detection(i, rssi);
+                last_report_ms[i] = now;
+            }
+        }
+    }
+}

--- a/rx5808-detection/src/rx5808.cpp
+++ b/rx5808-detection/src/rx5808.cpp
@@ -1,0 +1,75 @@
+#include "rx5808.h"
+
+// Standard FPV bands — Raceband, A, B, E, F (40 channels total).
+// Frequencies follow the community-standard channel plan.
+// Raceband R7 and Band F8 both land on 5880 MHz (same physical frequency).
+const FPVChannel FPV_CHANNELS[] = {
+    // Raceband
+    {5658, "R", 1}, {5695, "R", 2}, {5732, "R", 3}, {5769, "R", 4},
+    {5806, "R", 5}, {5843, "R", 6}, {5880, "R", 7}, {5917, "R", 8},
+    // Band A
+    {5865, "A", 1}, {5845, "A", 2}, {5825, "A", 3}, {5805, "A", 4},
+    {5785, "A", 5}, {5765, "A", 6}, {5745, "A", 7}, {5725, "A", 8},
+    // Band B
+    {5733, "B", 1}, {5752, "B", 2}, {5771, "B", 3}, {5790, "B", 4},
+    {5809, "B", 5}, {5828, "B", 6}, {5847, "B", 7}, {5866, "B", 8},
+    // Band E
+    {5705, "E", 1}, {5685, "E", 2}, {5665, "E", 3}, {5645, "E", 4},
+    {5885, "E", 5}, {5905, "E", 6}, {5925, "E", 7}, {5945, "E", 8},
+    // Band F (Fatshark)
+    {5740, "F", 1}, {5760, "F", 2}, {5780, "F", 3}, {5800, "F", 4},
+    {5820, "F", 5}, {5840, "F", 6}, {5860, "F", 7}, {5880, "F", 8},
+};
+const int FPV_CHANNEL_COUNT = (int)(sizeof(FPV_CHANNELS) / sizeof(FPV_CHANNELS[0]));
+
+// Shift 'bits' bits of 'data' out LSB-first on the bit-bang SPI bus.
+static void spi_shift_out(uint32_t data, int bits) {
+    for (int i = 0; i < bits; i++) {
+        digitalWrite(RX5808_CLK_PIN, LOW);
+        digitalWrite(RX5808_DATA_PIN, (data >> i) & 1);
+        delayMicroseconds(2);
+        digitalWrite(RX5808_CLK_PIN, HIGH);
+        delayMicroseconds(2);
+    }
+    digitalWrite(RX5808_CLK_PIN, LOW);
+}
+
+void rx5808_init() {
+    pinMode(RX5808_DATA_PIN, OUTPUT);
+    pinMode(RX5808_CLK_PIN,  OUTPUT);
+    pinMode(RX5808_CS_PIN,   OUTPUT);
+
+    digitalWrite(RX5808_DATA_PIN, LOW);
+    digitalWrite(RX5808_CLK_PIN,  LOW);
+    digitalWrite(RX5808_CS_PIN,   HIGH);  // deselected
+
+    // 0–3.3V attenuation covers the full RX5808 RSSI output range
+    analogSetAttenuation(ADC_11db);
+    analogReadResolution(12);
+}
+
+void rx5808_set_frequency(uint16_t freq_mhz) {
+    // Synthesizer B register data: standard formula used by RotorHazard / Chorus RF Laptimer.
+    // Frequency range: 5645–5945 MHz.
+    uint16_t reg_val = (freq_mhz - 479) / 2;
+
+    // 25-bit SPI word layout (LSB first):
+    //   bits  [3:0] = register address 0x01 (Synthesizer B)
+    //   bit   [4]   = R/W flag, 1 = write
+    //   bits [24:5] = 20-bit register data (upper 4 bits of reg_val are always 0
+    //                 for the 5.8GHz FPV band, so 16 bits are sufficient)
+    uint32_t spi_word = 0x01u | (1u << 4) | ((uint32_t)reg_val << 5);
+
+    digitalWrite(RX5808_CS_PIN, LOW);
+    spi_shift_out(spi_word, 25);
+    digitalWrite(RX5808_CS_PIN, HIGH);
+}
+
+int rx5808_read_rssi() {
+    long sum = 0;
+    for (int i = 0; i < RSSI_SAMPLES; i++) {
+        sum += analogRead(RX5808_RSSI_PIN);
+        delayMicroseconds(200);
+    }
+    return (int)(sum / RSSI_SAMPLES);
+}

--- a/rx5808-detection/src/rx5808.h
+++ b/rx5808-detection/src/rx5808.h
@@ -1,0 +1,51 @@
+#pragma once
+#include <Arduino.h>
+
+// ============================================================
+// RX5808 5.8GHz Analog FM Receiver — Driver
+//
+// XIAO ESP32-S3 Wiring:
+//   GPIO9  (D10/MOSI) → RX5808 DATA
+//   GPIO7  (D8/SCK)   → RX5808 CLK
+//   GPIO8  (D9)       → RX5808 CS  (active LOW)
+//   GPIO1  (D0/ADC)   ← RX5808 RSSI (analog output)
+//   3.3V              → RX5808 VCC
+//   GND               → RX5808 GND
+//
+// GPIO5 / GPIO6 are reserved for the optional Heltec UART relay.
+// ============================================================
+
+#define RX5808_DATA_PIN  9   // SPI MOSI (bit-bang)
+#define RX5808_CLK_PIN   7   // SPI clock
+#define RX5808_CS_PIN    8   // Chip select, active LOW
+#define RX5808_RSSI_PIN  1   // ADC1_CH0 — analog RSSI input
+
+// ADC signal threshold (0–4095, 12-bit).
+// The RX5808 RSSI output rises with signal strength.
+// Calibrate by checking idle noise floor and raising until false positives stop.
+#define RSSI_THRESHOLD   1800
+
+// Number of ADC samples averaged per RSSI reading
+#define RSSI_SAMPLES     10
+
+// PLL settle time (ms) after tuning before reading RSSI
+#define TUNE_SETTLE_MS   30
+
+// ============================================================
+// FPV Channel Descriptor
+// ============================================================
+struct FPVChannel {
+    uint16_t    freq_mhz;
+    const char* band;     // "R", "A", "B", "E", "F"
+    uint8_t     ch;       // 1–8
+};
+
+extern const FPVChannel FPV_CHANNELS[];
+extern const int        FPV_CHANNEL_COUNT;
+
+// ============================================================
+// Public API
+// ============================================================
+void rx5808_init();
+void rx5808_set_frequency(uint16_t freq_mhz);
+int  rx5808_read_rssi();


### PR DESCRIPTION
New firmware directory rx5808-detection/ targets XIAO ESP32-S3 and scans all 40 standard FPV channels (Raceband + Bands A/B/E/F) using a bit-banged SPI driver for the RX5808 module. Detections above the configurable RSSI threshold are emitted as JSON on USB Serial and as compact text on UART (GPIO5/6) for optional Heltec/Meshtastic relay.

mesh-mapper.py changes:
- Log RX5808 analog_fm detections with freq/band/channel detail
- Skip FAA registration lookup for analog_fm type (no RemoteID to query)
- Filter RX5808 startup info messages cleanly

Wiring: GPIO9=DATA, GPIO7=CLK, GPIO8=CS, GPIO1=RSSI (ADC), 3.3V/GND. Adjust RSSI_THRESHOLD in rx5808.h to calibrate against local noise floor.

